### PR TITLE
feat: add newsletter signup form

### DIFF
--- a/src/components/NewsletterForm.jsx
+++ b/src/components/NewsletterForm.jsx
@@ -1,0 +1,135 @@
+import { useState, useRef } from 'react';
+
+export default function NewsletterForm({ source }) {
+  const [email, setEmail] = useState('');
+  const [hp, setHp] = useState('');
+  const [status, setStatus] = useState('idle'); // idle | loading | success | error
+  const [message, setMessage] = useState('');
+
+  const mountedAt = useRef(Date.now());
+
+  const isDisabled = status === 'loading' || status === 'success';
+
+  const validateEmail = (value) => /\S+@\S+\.\S+/.test(value);
+
+  const handleChange = (e) => {
+    setEmail(e.target.value);
+    if (status === 'error') {
+      setStatus('idle');
+      setMessage('');
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (isDisabled) return;
+
+    if (!validateEmail(email)) {
+      setStatus('error');
+      setMessage('El email no parece válido.');
+      return;
+    }
+
+    if (hp || Date.now() - mountedAt.current < 2000) {
+      setStatus('error');
+      setMessage('No pudimos completar la suscripción. Probá más tarde.');
+      return;
+    }
+
+    setStatus('loading');
+
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          source,
+          hp,
+          submittedAt: new Date().toISOString(),
+        }),
+      });
+
+      if (res.ok) {
+        setStatus('success');
+        setMessage('¡Listo! Revisá tu correo para confirmar la suscripción.');
+
+        if (typeof window !== 'undefined') {
+          if (window.gtag) {
+            window.gtag('event', 'newsletter_subscribed');
+          }
+          if (window.dataLayer) {
+            window.dataLayer.push({ event: 'newsletter_subscribed', source });
+          }
+        }
+        return;
+      }
+
+      let data;
+      try {
+        data = await res.json();
+      } catch {
+        // ignore
+      }
+
+      if (res.status === 400 && data?.code === 'invalid_email') {
+        setMessage('El email no parece válido.');
+      } else if (res.status === 409 && data?.code === 'duplicate') {
+        setMessage('Ese email ya está registrado. Si no te llegó, revisá SPAM o intentá nuevamente.');
+      } else {
+        setMessage('No pudimos completar la suscripción. Probá más tarde.');
+      }
+      setStatus('error');
+    } catch {
+      setStatus('error');
+      setMessage('No pudimos completar la suscripción. Probá más tarde.');
+    }
+  };
+
+  return (
+    <form className="newsletter__form" onSubmit={handleSubmit} noValidate>
+      <div className="newsletter__input-group">
+        <input
+          type="email"
+          id="email-input"
+          className="newsletter__input"
+          placeholder="tucorreo@ejemplo.com"
+          value={email}
+          onChange={handleChange}
+          aria-describedby="email-help"
+          aria-invalid={status === 'error'}
+          disabled={isDisabled}
+          required
+        />
+        {/* Honeypot field */}
+        <input
+          type="text"
+          name="hp"
+          value={hp}
+          onChange={(e) => setHp(e.target.value)}
+          tabIndex="-1"
+          autoComplete="off"
+          style={{ position: 'absolute', left: '-5000px', opacity: 0 }}
+          aria-hidden="true"
+        />
+        <button type="submit" className="newsletter__button" disabled={isDisabled}>
+          {status === 'loading' ? 'Enviando...' : status === 'success' ? '¡Enviado!' : 'Suscribirme'}
+        </button>
+      </div>
+      <div id="email-help" className="newsletter__help" aria-live="polite">
+        Te enviaremos un email de confirmación
+      </div>
+      {message && (
+        <div
+          className={`newsletter__message ${
+            status === 'success' ? 'newsletter__message--success' : 'newsletter__message--error'
+          }`}
+          role="alert"
+          aria-live="assertive"
+        >
+          {message}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/src/landing/LandingPage.jsx
+++ b/src/landing/LandingPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import './LandingPage.css';
+import NewsletterForm from '../components/NewsletterForm.jsx';
 
 export default function LandingPage() {
   return (
@@ -26,16 +27,10 @@ export default function LandingPage() {
         <section id="inicio" className="hero">
           <h1 className="hero__title">Encontrá la yerba mate perfecta para vos</h1>
           <p className="hero__subtitle">Nobilerde usa inteligencia artificial y la voz de miles de materos para recomendarte las mejores marcas según tu gusto.</p>
-          {/* Formulario de Newsletter (puedes migrar el JS a React si lo deseas) */}
+          {/* Formulario de Newsletter */}
           <div className="newsletter">
             <label className="newsletter__label" htmlFor="email-input">Recibí novedades antes que nadie</label>
-            <form className="newsletter__form" id="newsletter-form" action="#" method="POST">
-              <div className="newsletter__input-group">
-                <input type="email" id="email-input" className="newsletter__input" placeholder="tucorreo@ejemplo.com" required aria-describedby="email-help" />
-                <button type="submit" className="newsletter__button">Suscribirme</button>
-              </div>
-              <div id="email-help" className="newsletter__help">Te enviaremos un email de confirmación</div>
-            </form>
+            <NewsletterForm source="landing-hero" />
             <div className="privacy-notice">
               Tus datos se usan solo para enviarte novedades de Nobilerde. Podés darte de baja cuando quieras. <a href="privacidad.html">Ver política de privacidad</a>.
             </div>


### PR DESCRIPTION
## Summary
- replace static newsletter form with `NewsletterForm` React component
- post subscriptions to `/api/subscribe` with honeypot and time gate spam protection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a504ff5400832982434e1ffeaddf6c